### PR TITLE
Fix overlapping exported config

### DIFF
--- a/config
+++ b/config
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 export MEMCACHED_IMAGE=${MEMCACHED_IMAGE:="memcached"}
 export MEMCACHED_IMAGE_VERSION=${MEMCACHED_IMAGE_VERSION:="1.4.24"}
-export MEMCACHED_ROOT=/var/lib/dokku/services/memcached
+export MEMCACHED_ROOT=${MEMCACHED_ROOT:="/var/lib/dokku/services/memcached"}
 
 export PLUGIN_COMMAND_PREFIX="memcached"
-export PLUGIN_DATA_ROOT=${PLUGIN_DATA_ROOT:="$MEMCACHED_ROOT"}
+export PLUGIN_DATA_ROOT=$MEMCACHED_ROOT
 export PLUGIN_DATASTORE_PORTS=(11211)
 export PLUGIN_DEFAULT_ALIAS="MEMCACHED"
 export PLUGIN_IMAGE=$MEMCACHED_IMAGE

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -8,7 +8,8 @@ export PLUGIN_PATH="$DOKKU_ROOT/plugins"
 export PLUGIN_ENABLED_PATH="$PLUGIN_PATH"
 export PLUGIN_AVAILABLE_PATH="$PLUGIN_PATH"
 export PLUGIN_CORE_AVAILABLE_PATH="$PLUGIN_PATH"
-export PLUGIN_DATA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures"
+export MEMCACHED_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures"
+export PLUGIN_DATA_ROOT="$MEMCACHED_ROOT"
 
 mkdir -p "$PLUGIN_DATA_ROOT"
 rm -rf "${PLUGIN_DATA_ROOT:?}"/*


### PR DESCRIPTION
If using multiple official dokku datastorage plugins, it is possible to get into a case where the `PLUGIN_DATA_ROOT` would be set incorrectly for other plugins.

Refs dokku/dokku-redis#20